### PR TITLE
fix: Reduce OpenSearch cluster size

### DIFF
--- a/samples/document_explorer/bin/document_explorer.ts
+++ b/samples/document_explorer/bin/document_explorer.ts
@@ -29,10 +29,10 @@ const persistence = new PersistenceStack(app, 'PersistenceStack', {
   securityGroups: network.securityGroups,
   masterNodes: 3,
   dataNodes: 3,
-  masterNodeInstanceType: 'm6g.4xlarge.search',
-  dataNodeInstanceType: 'r6g.8xlarge.search',
+  masterNodeInstanceType: 'm6g.large.search',
+  dataNodeInstanceType: 'm6g.large.search',
   availabilityZoneCount: 3,
-  volumeSize: 100,
+  volumeSize: 20,
   removalPolicy: cdk.RemovalPolicy.DESTROY
 });
 cdk.Tags.of(persistence).add("stack", "persistence");

--- a/samples/document_explorer/lib/persistence-stack.ts
+++ b/samples/document_explorer/lib/persistence-stack.ts
@@ -16,8 +16,8 @@ export interface PersistenceProps extends StackProps {
   securityGroups: ec2.SecurityGroup[];
   masterNodes: 1 | 3 | 5;
   dataNodes: number;
-  masterNodeInstanceType: 't3.small.search' | 't3.medium.search' | 'm6g.4xlarge.search' | 'm6g.8xlarge.search';
-  dataNodeInstanceType: 't3.small.search' | 't3.medium.search' | 'r6g.4xlarge.search' | 'r6g.8xlarge.search';
+  masterNodeInstanceType: 'm6g.large.search' | 'm6g.4xlarge.search' | 'm6g.8xlarge.search';
+  dataNodeInstanceType: 'm6g.large.search' | 'r6g.4xlarge.search' | 'r6g.8xlarge.search';
   availabilityZoneCount:number;
   volumeSize: number;
   removalPolicy: cdk.RemovalPolicy;


### PR DESCRIPTION
This commit fixes an issue with the OpenSearch cluster being too large. It reduces the cluster size to optimize costs.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
