### PR TITLE
fix: when dot is in the filepath

### DIFF
--- a/samples/document_explorer/client_app/pages/2_🏷️_Summary.py
+++ b/samples/document_explorer/client_app/pages/2_🏷️_Summary.py
@@ -33,8 +33,7 @@ def get_selected_source_filename():
     if not selected_file:
         return None
 
-    base_name = os.path.splitext(selected_file)[0]
-    return f"{base_name}.pdf"
+    return f"{selected_file}.pdf"
 
 # Get selected source file if authenticated
 selected_file = get_selected_source_filename()

--- a/samples/document_explorer/client_app/pages/3_💬_Q&A.py
+++ b/samples/document_explorer/client_app/pages/3_💬_Q&A.py
@@ -27,7 +27,7 @@ def get_selected_filename():
     if not selected_file:
         return None
     
-    return os.path.splitext(selected_file)[0]
+    return selected_file
 
 def get_selected_transformed_filename():
     """Get selected source filename from session state."""
@@ -36,8 +36,7 @@ def get_selected_transformed_filename():
     if not selected_file:
         return None
 
-    base_name = os.path.splitext(selected_file)[0]
-    return f"{base_name}.txt"
+    return f"{selected_file}.txt"
 
 selected_filename = get_selected_filename()
 


### PR DESCRIPTION
*Description of changes:*
When a dot, `.`, is in the filename the document selection assumed everything after was an extension. Removed the code to parse the extension as it wasn't relevant.

_NOTE: Without the change uploading `filename.01.pdf` will cause a fatal error and require logging out to remediate_

* Also, it would introduce false processing when different files named `file01.pdf` and `file01.different.pdf` are uploaded as picking `file01.different` will actually pick `file01`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
