### PR TITLE
feat(rag): add option for long context

### DIFF
--- a/samples/document_explorer/client_app/graphql/mutations.py
+++ b/samples/document_explorer/client_app/graphql/mutations.py
@@ -31,6 +31,7 @@ class Mutations:
             $max_docs: Int
             $verbose: Boolean
             $streaming: Boolean
+            $responseGenerationMethod: String
             ) {
             postQuestion(
                 jobid: $jobid
@@ -40,6 +41,7 @@ class Mutations:
                 max_docs: $max_docs
                 verbose: $verbose
                 streaming: $streaming
+                responseGenerationMethod: $responseGenerationMethod
             ) {
                 __typename
             }

--- a/samples/document_explorer/client_app/pages/3_💬_Q&A.py
+++ b/samples/document_explorer/client_app/pages/3_💬_Q&A.py
@@ -47,6 +47,7 @@ def post_question_about_selected_file():
     """Send summary job request to GraphQL API."""
 
     selected_transformed_filename = get_selected_transformed_filename()
+    generative_method = st.session_state.get("generative_method", "LONG_CONTEXT")
     if auth.is_authenticated() and selected_transformed_filename:
         # Get user tokens
         access_token, id_token = auth.get_user_tokens()
@@ -66,8 +67,12 @@ def post_question_about_selected_file():
             "question": st.session_state.get("encoded_question", ""),
             "max_docs": 1,
             "verbose": False,
-            "streaming": True
+            "streaming": True,
+            "responseGenerationMethod": generative_method
         }
+        # print the variables
+        print(variables, "variables")
+        # console.log(variables, "variables")
         return mutation_client.execute(Mutations.POST_QUESTION, "PostQuestion", variables)
 
     return None
@@ -147,6 +152,14 @@ auth.print_login_logout_buttons()
 
 # Logged in user UI
 if auth.is_authenticated() and selected_filename:
+    # Add a radio button for method selection
+    generative_method = st.radio(
+        "Select Response Generation Method:",
+        ('RAG', 'LONG_CONTEXT')
+    )
+    # Add a divider here
+    st.markdown("---")
+    st.session_state['generative_method'] = generative_method
 
     # Initialize chat history
     if "messages_filename" not in st.session_state or st.session_state.messages_filename != selected_filename:


### PR DESCRIPTION
feat(rag): add option for long context

### IMPORTANT 
- This PR (https://github.com/awslabs/generative-ai-cdk-constructs/pull/176) must be merged in first.

*Issue #, if available:*

- Adds the option to select RAG or LONG CONTEXT for the RAG section

*Description of changes:*
- Change the mutation signature to match new RAG signature
- Add Radio buttons
- Pull in variable from FE to feed to GraphQL

### Preview


![Screenshot 2024-01-15 at 8 14 42 PM](https://github.com/aws-samples/generative-ai-cdk-constructs-samples/assets/11032490/01afdce5-2233-48a0-aca8-d5e0f903c492)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
