### PR TITLE
Fix/chat history and cognito helper

### DIFF
--- a/samples/document_explorer/client_app/common/cognito_helper.py
+++ b/samples/document_explorer/client_app/common/cognito_helper.py
@@ -119,11 +119,11 @@ class CognitoHelper:
         """Sets session state variables after authentication."""
         try:
             
-            auth_query_params = dict(st.experimental_get_query_params())
-            if "code" not in auth_query_params or not auth_query_params["code"][0]:
+            auth_query_params = st.query_params.to_dict()
+            if "code" not in auth_query_params or not auth_query_params["code"]:
                 return
 
-            auth_code = auth_query_params["code"][0]
+            auth_code = auth_query_params["code"]
             access_token, id_token = self.get_user_tokens(auth_code)
 
             if access_token != "":

--- a/samples/document_explorer/client_app/pages/3_💬_Q&A.py
+++ b/samples/document_explorer/client_app/pages/3_💬_Q&A.py
@@ -1,6 +1,7 @@
 # Standard library imports
 import os
 import base64
+from copy import copy
 # Third party imports 
 import streamlit as st
 from dotenv import load_dotenv
@@ -103,6 +104,8 @@ def on_message_update(message, subscription_client):
 
     elif status == "LLM streaming ended":
         st.session_state.message_widget.markdown(st.session_state.message_widget_text)
+        if st.session_state.messages[-1]['role'] == 'assistant':
+            st.session_state.messages[-1]['content'] = copy(st.session_state.message_widget_text)
         subscription_client.unsubscribe()
 
 


### PR DESCRIPTION
This PR includes two fixes:

1. Persist chat history when receiving assistant messages
2. Use updated Streamlit API method

## Changes

### Persist chat history
Fix loss of assistant chat history by copying the content of `message_widget_text` instead of storing a reference. Reference was being cleared on each new user interaction, losing history.

### Use updated Streamlit API  
t.experimental_get_query_params was deprecated in Streamlit 1.30.0. Switch to using st.query_params instead. See [Streamlit API reference](https://docs.streamlit.io/library/api-reference/utilities/st.experimental_get_query_params) for more details on the deprecation.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
