### PR TITLE
fix: response method is ResponseGenerationMethod not string

### DIFF
--- a/samples/document_explorer/client_app/graphql/mutations.py
+++ b/samples/document_explorer/client_app/graphql/mutations.py
@@ -31,7 +31,7 @@ class Mutations:
             $max_docs: Int
             $verbose: Boolean
             $streaming: Boolean
-            $responseGenerationMethod: String
+            $responseGenerationMethod: ResponseGenerationMethod
             ) {
             postQuestion(
                 jobid: $jobid


### PR DESCRIPTION
*Description of changes:*

The mutation call was inadvertently set to`String` instead of `ResponseGenerationMethod`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
