### PR TITLE
fix: use 0.1.36 @cdklabs/generative-ai-cdk-constructs

### DIFF
--- a/samples/document_explorer/package-lock.json
+++ b/samples/document_explorer/package-lock.json
@@ -8,8 +8,8 @@
       "name": "document_explorer",
       "version": "0.1.1",
       "dependencies": {
-        "@cdklabs/generative-ai-cdk-constructs": "^0.1.30",
-        "aws-cdk-lib": "^2.114.0",
+        "@cdklabs/generative-ai-cdk-constructs": "^0.1.36",
+        "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.3.0",
         "source-map-support": "^0.5.21"
       },
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.201",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz",
-      "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ=="
+      "version": "2.2.202",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
@@ -678,17 +678,17 @@
       "dev": true
     },
     "node_modules/@cdklabs/generative-ai-cdk-constructs": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.30.tgz",
-      "integrity": "sha512-LJAWrwCRPJjRVN9uu3wuykaexqgkj3Nx/w41fzo9WlhWQLdEHi/et0mb26fZ+xCUbNRoaigP2EhqSxR6HDe4YA==",
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.36.tgz",
+      "integrity": "sha512-7fZx08XGN3XKbHXVVEpYoDlF5kRHCpLytwqwmagU/nT6nDs2/Is5MMDC+j3zZGTxZDUQl8nwWHeI1TtoM6bCqg==",
       "dependencies": {
-        "cdk-nag": "^2.28.10"
+        "cdk-nag": "^2.28.11"
       },
       "engines": {
         "node": ">= 18.12.0 <= 20.x"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.114.0",
+        "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.3.0"
       }
     },
@@ -1498,9 +1498,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.118.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.118.0.tgz",
-      "integrity": "sha512-i3At9HOuXNVLxQCo/y7Sb2Zj4Ir4tichG+755AAldebRcqXrCJizZq+sMMt6/Bkjggj2imWmhwHPZw518M9VMw==",
+      "version": "2.116.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.116.0.tgz",
+      "integrity": "sha512-LOYJGtKLvf/wVt3UMwWQxvxgAM681ZV/BbGGB6aEqc7+4TMfbYFbaA02+zwN0E0zxOxi4l0j1/BNO4GOzVSoPw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/samples/document_explorer/package.json
+++ b/samples/document_explorer/package.json
@@ -21,8 +21,8 @@
     "typescript": "~5.2.2"
   },
   "dependencies": {
-    "@cdklabs/generative-ai-cdk-constructs": "^0.1.29",
-    "aws-cdk-lib": "^2.111.0",
+    "@cdklabs/generative-ai-cdk-constructs": "^0.1.36",
+    "aws-cdk-lib": "^2.116.0",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
Use the latest version of the @cdklabs/generative-ai-cdk-constructs `0.1.36` library


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
