### PR TITLE
feat: add clientUrl environmental variable

### DIFF
--- a/samples/document_explorer/bin/document_explorer.ts
+++ b/samples/document_explorer/bin/document_explorer.ts
@@ -9,6 +9,7 @@ import { ApiStack } from '../lib/api-stack';
 const env = {
     region: process.env.CDK_DEFAULT_REGION,
     account: process.env.CDK_DEFAULT_ACCOUNT,
+    clientUrl: process.env.STREAMLIT_CLIENTURL? process.env.STREAMLIT_CLIENTURL : "http://localhost:8501"
 }
 const app = new cdk.App();
 cdk.Tags.of(app).add("app", "generative-ai-cdk-constructs-samples");
@@ -55,7 +56,7 @@ const api = new ApiStack(app, 'ApiStack', {
   engine: 'redis',
   numCacheNodes: 1,
   removalPolicy: cdk.RemovalPolicy.DESTROY,
-  clientUrl: 'http://localhost:8501/'
+  clientUrl: env.clientUrl
 });
 cdk.Tags.of(api).add("stack", "api");
 


### PR DESCRIPTION
This will allow an environmental variable `STREAMLIT_CLIENTURL` to be used in place of the default "http://localhost:8501" for the cognito callbacks and ApiStack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
