### PR TITLE
feat(cost): costs optimization

### DIFF
--- a/samples/document_explorer/bin/document_explorer.ts
+++ b/samples/document_explorer/bin/document_explorer.ts
@@ -35,7 +35,8 @@ const persistence = new PersistenceStack(app, 'PersistenceStack', {
   openSearchServiceType: 'aoss',
   openSearchProps: {
     openSearchVpcEndpointId: network.openSearchVpcEndpoint.attrId,
-    collectionName: 'doc-explorer'
+    collectionName: 'doc-explorer',
+    standbyReplicas: 'DISABLED'
   } as OpenSearchServerlessProps,
   removalPolicy: cdk.RemovalPolicy.DESTROY  
 });

--- a/samples/document_explorer/bin/document_explorer.ts
+++ b/samples/document_explorer/bin/document_explorer.ts
@@ -21,6 +21,7 @@ cdk.Aspects.of(app).add(new AwsSolutionsChecks({verbose:true}));
 const network = new NetworkingStack(app, 'NetworkingStack', {
   env: env,
   openSearchServiceType: 'aoss',
+  natGateways: 1
 });
 cdk.Tags.of(network).add("stacl", "network");
 

--- a/samples/document_explorer/lib/networking-stack.ts
+++ b/samples/document_explorer/lib/networking-stack.ts
@@ -8,6 +8,7 @@ import * as openSearchServerless from 'aws-cdk-lib/aws-opensearchserverless';
 
 export interface NetworkingProps extends StackProps {
     openSearchServiceType: 'es' | 'aoss';
+    natGateways?: number;
 }
 
 export class NetworkingStack extends Stack {
@@ -41,7 +42,8 @@ export class NetworkingStack extends Stack {
                 cidrMask: 24,
             },
             ],
-            ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16')
+            ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16'),
+            natGateways: props.natGateways,
         });
 
         //---------------------------------------------------------------------

--- a/samples/document_explorer/lib/persistence-stack.ts
+++ b/samples/document_explorer/lib/persistence-stack.ts
@@ -24,6 +24,7 @@ export interface OpenSearchServiceProps extends ResourceProps {
 export interface OpenSearchServerlessProps extends ResourceProps {
   openSearchVpcEndpointId: string;
   collectionName: string;
+  standbyReplicas?: string;
 }
 
 export interface PersistenceProps extends StackProps {
@@ -255,7 +256,8 @@ export class PersistenceStack extends Stack {
       this.opensearchCollection = new openSearchServerless.CfnCollection(this, 'Collection', {
         name: openSearchProps.collectionName,
         description: 'Vector search collection',
-        type: 'VECTORSEARCH'
+        type: 'VECTORSEARCH',
+        standbyReplicas: openSearchProps.standbyReplicas
       });
       this.opensearchCollection.addDependency(encryptionPolicy);
       this.opensearchCollection.addDependency(dataAccessPolicy);

--- a/samples/document_explorer/package-lock.json
+++ b/samples/document_explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "document_explorer",
       "version": "0.1.1",
       "dependencies": {
-        "@cdklabs/generative-ai-cdk-constructs": "^0.1.46",
+        "@cdklabs/generative-ai-cdk-constructs": "^0.1.50",
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.3.0",
         "source-map-support": "^0.5.21"
@@ -678,11 +678,11 @@
       "dev": true
     },
     "node_modules/@cdklabs/generative-ai-cdk-constructs": {
-      "version": "0.1.46",
-      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.46.tgz",
-      "integrity": "sha512-MKktvK/LWSOaFTZAfj0/MfoAa6f5Wg9PLgSEMpR8bFJsHkPH7dItjGf/JiIolLBt2RqB3HGfshXIlbPAVdJBTw==",
+      "version": "0.1.50",
+      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.50.tgz",
+      "integrity": "sha512-YcocXwNoBXiz8p9ByYmNbuNmT8ih13efFKKV2x62pdTT2YnUttrliQRfxJPWI1E0EW+WH5xR93Ww9DzI048FUA==",
       "dependencies": {
-        "cdk-nag": "^2.28.23"
+        "cdk-nag": "^2.28.25"
       },
       "engines": {
         "node": ">= 18.12.0 <= 20.x"
@@ -2187,9 +2187,9 @@
       "dev": true
     },
     "node_modules/cdk-nag": {
-      "version": "2.28.24",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.24.tgz",
-      "integrity": "sha512-OwoqNoS2zFuNI6xZ9U4oTRO5GgAPwUYOEeWH5Gw+tYQGRWhKaxYHl0vfEp7qgrr086YwmLZjJ3zbel+nwpXy8Q==",
+      "version": "2.28.26",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.26.tgz",
+      "integrity": "sha512-UvqK+Mkt/aamcyRE2jxW4Y9y7Q8dnyVHmz9dEXR2fnv3cXuuNxo9uPz63Q/+VaQWuk/I6X0+QWUQGfj+Ao4nEg==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.0.5"

--- a/samples/document_explorer/package.json
+++ b/samples/document_explorer/package.json
@@ -21,7 +21,7 @@
     "typescript": "~5.2.2"
   },
   "dependencies": {
-    "@cdklabs/generative-ai-cdk-constructs": "^0.1.46",
+    "@cdklabs/generative-ai-cdk-constructs": "^0.1.50",
     "aws-cdk-lib": "^2.116.0",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
This PR includes the following:
- feat(cost): reduce NAT gateways to 1
- feat(cost): disable standby replicas for OpenSearch Serverless

It reduces costs by adding `natGateways` and `standbyReplicas` configuration options to the sample doc explorer app. These are set to reduce high availability in exchange for cost optimization. As they are configurable parameters, users can adjust as needed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
