### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/samples/document_explorer/package-lock.json
+++ b/samples/document_explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "document_explorer",
       "version": "0.1.1",
       "dependencies": {
-        "@cdklabs/generative-ai-cdk-constructs": "^0.1.50",
+        "@cdklabs/generative-ai-cdk-constructs": "^0.1.52",
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.3.0",
         "source-map-support": "^0.5.21"
@@ -678,11 +678,11 @@
       "dev": true
     },
     "node_modules/@cdklabs/generative-ai-cdk-constructs": {
-      "version": "0.1.50",
-      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.50.tgz",
-      "integrity": "sha512-YcocXwNoBXiz8p9ByYmNbuNmT8ih13efFKKV2x62pdTT2YnUttrliQRfxJPWI1E0EW+WH5xR93Ww9DzI048FUA==",
+      "version": "0.1.52",
+      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.52.tgz",
+      "integrity": "sha512-V4PWlQaRMvT/OYaeOdwUx6cWBHkymEzmo04Oi58GN9fJipQAepqDhAJUgyI14lDEngipIgeY9fD6gm/Jt1cP1g==",
       "dependencies": {
-        "cdk-nag": "^2.28.25"
+        "cdk-nag": "^2.28.26"
       },
       "engines": {
         "node": ">= 18.12.0 <= 20.x"

--- a/samples/document_explorer/package.json
+++ b/samples/document_explorer/package.json
@@ -21,7 +21,7 @@
     "typescript": "~5.2.2"
   },
   "dependencies": {
-    "@cdklabs/generative-ai-cdk-constructs": "^0.1.50",
+    "@cdklabs/generative-ai-cdk-constructs": "^0.1.52",
     "aws-cdk-lib": "^2.116.0",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
chore(deps): upgrade dependencies

Version ```0.1.52``` of ```@cdklabs/generative-ai-cdk-constructs``` now allows executing:
```cdk deploy --context maximumLambdaMemorySize=3008 --all```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
