### PR TITLE
chore(elasticache): optimize cache node type

### DIFF
--- a/samples/document_explorer/bin/document_explorer.ts
+++ b/samples/document_explorer/bin/document_explorer.ts
@@ -54,7 +54,7 @@ const api = new ApiStack(app, 'ApiStack', {
   existingInputAssetsBucketObj: persistence.inputAssetsBucket,
   existingProcessedAssetsBucketObj: persistence.processedAssetsBucket,
   openSearchIndexName: 'doc-explorer',
-  cacheNodeType: 'cache.r6g.xlarge',
+  cacheNodeType: 'cache.t4g.medium',
   engine: 'redis',
   numCacheNodes: 1,
   removalPolicy: cdk.RemovalPolicy.DESTROY,

--- a/samples/document_explorer/package-lock.json
+++ b/samples/document_explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "document_explorer",
       "version": "0.1.1",
       "dependencies": {
-        "@cdklabs/generative-ai-cdk-constructs": "^0.1.52",
+        "@cdklabs/generative-ai-cdk-constructs": "^0.1.57",
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.3.0",
         "source-map-support": "^0.5.21"
@@ -678,11 +678,11 @@
       "dev": true
     },
     "node_modules/@cdklabs/generative-ai-cdk-constructs": {
-      "version": "0.1.52",
-      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.52.tgz",
-      "integrity": "sha512-V4PWlQaRMvT/OYaeOdwUx6cWBHkymEzmo04Oi58GN9fJipQAepqDhAJUgyI14lDEngipIgeY9fD6gm/Jt1cP1g==",
+      "version": "0.1.57",
+      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.57.tgz",
+      "integrity": "sha512-L16dVyBgkdQBAlg3c6DzQZiIN0WDEj7xwnkajEimwgOevppfL+w0WZGrEC+5b8eDS1iuQy3otDQWGcrqiWHBoA==",
       "dependencies": {
-        "cdk-nag": "^2.28.26"
+        "cdk-nag": "^2.28.27"
       },
       "engines": {
         "node": ">= 18.12.0 <= 20.x"
@@ -2187,9 +2187,9 @@
       "dev": true
     },
     "node_modules/cdk-nag": {
-      "version": "2.28.26",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.26.tgz",
-      "integrity": "sha512-UvqK+Mkt/aamcyRE2jxW4Y9y7Q8dnyVHmz9dEXR2fnv3cXuuNxo9uPz63Q/+VaQWuk/I6X0+QWUQGfj+Ao4nEg==",
+      "version": "2.28.27",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.27.tgz",
+      "integrity": "sha512-b9QnWZ6KPoFZtowMxYPlsdTEoMrOfg0jRx09gr4525uHlO6gWf+eNJtXUmQRYcBgaWF05a9vGBnbq+QKoslbNw==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.0.5"

--- a/samples/document_explorer/package.json
+++ b/samples/document_explorer/package.json
@@ -21,7 +21,7 @@
     "typescript": "~5.2.2"
   },
   "dependencies": {
-    "@cdklabs/generative-ai-cdk-constructs": "^0.1.52",
+    "@cdklabs/generative-ai-cdk-constructs": "^0.1.57",
     "aws-cdk-lib": "^2.116.0",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
Switch the cache node type from `cache.r6g.xlarge` to `cache.t4g.medium` to optimize cost

The `t4g.medium` instance provides `3.09` GB of memory, which is adequate for the sample workload and provides acceptable performance. More info [here](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html).

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
