### PR TITLE
fix: allow setup to run idempotent

### DIFF
--- a/samples/document_explorer/check_appsync.py
+++ b/samples/document_explorer/check_appsync.py
@@ -19,7 +19,7 @@ from botocore.exceptions import ClientError
 import requests
 from requests_aws4auth import AWS4Auth
 
-cdk_deploy_output_file = 'apistack-outputs.json'
+cdk_deploy_output_file = 'apistack-outputs.json' if len(sys.argv) < 2 else sys.argv[1]
 
 if os.path.isfile(cdk_deploy_output_file):
     with open(cdk_deploy_output_file) as cdk_deploy_output:

--- a/samples/document_explorer/empty_buckets.py
+++ b/samples/document_explorer/empty_buckets.py
@@ -18,7 +18,7 @@ import time
 import boto3
 from botocore.exceptions import ClientError
 
-cdk_deploy_output_file = 'apistack-outputs.json'
+cdk_deploy_output_file = 'apistack-outputs.json' if len(sys.argv) < 2 else sys.argv[1]
 
 if os.path.isfile(cdk_deploy_output_file):
     with open(cdk_deploy_output_file) as cdk_deploy_output:

--- a/samples/document_explorer/package-lock.json
+++ b/samples/document_explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "document_explorer",
       "version": "0.1.1",
       "dependencies": {
-        "@cdklabs/generative-ai-cdk-constructs": "^0.1.57",
+        "@cdklabs/generative-ai-cdk-constructs": ">=0.1.57  <=0.1.79",
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.3.0",
         "source-map-support": "^0.5.21"


### PR DESCRIPTION
*Description of changes:*

The `setup_client_app.py` if run multiple times would fail because the sample cognito user would already exist.

* Also, adjusted for sending in the CDK output file location.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
