### PR TITLE
fix(doc): add install instructions for sagemaker jumpstart model

### DIFF
--- a/samples/sagemaker_jumpstart_model/README.md
+++ b/samples/sagemaker_jumpstart_model/README.md
@@ -68,14 +68,19 @@ This project is built using the [AWS Cloud Development Kit (CDK)](https://aws.am
     cd samples/sagemaker_jumpstart_model
     ```
 
-3. Accept the EULA (End User License Agreement)
+3. Install packages
+   ```shell
+   npm install
+   ```
+
+4. Accept the EULA (End User License Agreement)
 
 Some JumpStart foundation models require explicit acceptance of an end-user license agreement (EULA) before deployment. The accept_eula value is set to false by default and must be explicitly redefined as true in order to accept the end-user license agreement. 
 To change this value:
 - go to [lambda.py](./lambda/lambda.py) and update the value of ```CustomAttributes="accept_eula=false"``` to ```CustomAttributes="accept_eula=true"```. If you try to run inference while accept_eula is set to false, the inference will fail and an error message will be returned.
-- go to [](./lib/sagemaker_jumpstart_model-stack.ts) and update the property ```acceptEula``` to true. If you try to synthesize the stack without setting that property to true, the process will fail.
+- go to [sagemaker_jumpstart_model-stack.ts](./lib/sagemaker_jumpstart_model-stack.ts) and update the property ```acceptEula``` to true. If you try to synthesize the stack without setting that property to true, the process will fail.
 
-3. Boostrap AWS CDK resources on the AWS account.
+5. Boostrap AWS CDK resources on the AWS account.
     ```shell
     cdk bootstrap aws://ACCOUNT_ID/REGION
     ```


### PR DESCRIPTION
Issue #47

*Description of changes:*
The `README.md` added the step to install packages for the SageMaker Jumpstart Model sample.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
