### PR TITLE
fix: bundler for poetry and updated signature for agents

### DIFF
--- a/samples/python-samples/app.py
+++ b/samples/python-samples/app.py
@@ -17,7 +17,7 @@ env = cdk.Environment(account=os.getenv('CDK_DEFAULT_ACCOUNT'),
 # Bedrock knowledge base with OpenSearch
 #---------------------------------------------------------------------------
 
-BedrockOpensearchStack(app, "BedrockOpensearchStack",
+BedrockOpensearchStack(app, "BedrockOpensearchStack"+os.getenv('SUFFIX',''),
     env=env
     )
 

--- a/samples/python-samples/python_samples/bedrock_opensearch_stack.py
+++ b/samples/python-samples/python_samples/bedrock_opensearch_stack.py
@@ -13,7 +13,7 @@ from cdklabs.generative_ai_cdk_constructs import (
     bedrock,
     
 )
-from aws_cdk.aws_lambda_python_alpha import ( PythonFunction,PythonLayerVersion)
+from aws_cdk.aws_lambda_python_alpha import ( BundlingOptions,PythonFunction,PythonLayerVersion)
 
 
 
@@ -51,6 +51,7 @@ class BedrockOpensearchStack(Stack):
             entry= os.path.join(os.path.dirname(__file__), '../lambda/action-group/'),
             layers= [_lambda.LayerVersion.from_layer_version_arn(self, 'PowerToolsLayer', f'arn:aws:lambda:{self.region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:60')],
             timeout= Duration.minutes(2),
+            bundling = BundlingOptions(build_args={"POETRY_VERSION": "1.7.0"})
         )       
         ag = bedrock.AgentActionGroup(
                 self, 

--- a/samples/python-samples/python_samples/bedrock_opensearch_stack.py
+++ b/samples/python-samples/python_samples/bedrock_opensearch_stack.py
@@ -58,7 +58,9 @@ class BedrockOpensearchStack(Stack):
                 'ActionGroup',
                 action_group_name='query-library',
                 description= 'Use these functions to get information about the books in the library.',
-                action_group_executor= action_group_function,
+                action_group_executor=bedrock.ActionGroupExecutor(
+                  lambda_=action_group_function,
+                ),
                 action_group_state= 'ENABLED',
                 api_schema= bedrock.ApiSchema.from_asset(os.path.join(os.path.dirname(__file__), 'action-group.yaml'))
                 ) 

--- a/samples/python-samples/python_samples/bedrock_pinecone_stack.py
+++ b/samples/python-samples/python_samples/bedrock_pinecone_stack.py
@@ -14,7 +14,7 @@ from cdklabs.generative_ai_cdk_constructs import (
     bedrock,
     pinecone
 )
-from aws_cdk.aws_lambda_python_alpha import ( PythonFunction,PythonLayerVersion)
+from aws_cdk.aws_lambda_python_alpha import ( BundlingOptions,PythonFunction,PythonLayerVersion)
 
 class BedrockPineconeStack(Stack):
 
@@ -60,7 +60,7 @@ class BedrockPineconeStack(Stack):
             entry= os.path.join(os.path.dirname(__file__), '../lambda/action-group/'),
             layers= [_lambda.LayerVersion.from_layer_version_arn(self, 'PowerToolsLayer', f'arn:aws:lambda:{self.region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:60')],
             timeout= Duration.minutes(2),
-
+            bundling = BundlingOptions(build_args={"POETRY_VERSION": "1.7.0"}),
         )       
 
         ag = bedrock.AgentActionGroup(
@@ -68,7 +68,9 @@ class BedrockPineconeStack(Stack):
                 'ActionGroup',
                 action_group_name='query-library',
                 description= 'Use these functions to get information about the books in the library.',
-                action_group_executor= action_group_function,
+                action_group_executor=bedrock.ActionGroupExecutor(
+                  lambda_=action_group_function,
+                ),
                 action_group_state= 'ENABLED',
                 api_schema= bedrock.ApiSchema.from_asset(os.path.join(os.path.dirname(__file__), 'action-group.yaml'))
                 ) 


### PR DESCRIPTION
*Issue #, if available:*
The builds default poetry is currently `1.5.1` and the `poetry.lock`  was generated by `1.7.0`
Also, the `action_group_executor` signature in the L1 constructs was updated.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
