### PR TITLE
fix: document non-x86 instructions

### DIFF
--- a/samples/contract-compliance-analysis/back-end/README.md
+++ b/samples/contract-compliance-analysis/back-end/README.md
@@ -9,12 +9,12 @@ You have the option of running the setup from a local workspace or from a Cloud9
 In case you opt for Cloud9, you have to setup a Cloud9 environment in the same AWS Account where this Backend will
 be installed.
 
-If your local workspace has a non-x86 processor architecture (for instance ARM, like the M processor from Macbooks), it's strongly recommended to perform the setup steps from a Cloud9 environment, to avoid bundling issues of Lambda function dependencies (see [ticket](https://github.com/awslabs/generative-ai-cdk-constructs/issues/541)) 
+If your local workspace has a non-x86 processor architecture (for instance ARM, like the M processor from Macbooks), it's strongly recommended to perform the setup steps from a Cloud9 environment, to avoid bundling issues of Lambda function dependencies (see [ticket](https://github.com/awslabs/generative-ai-cdk-constructs/issues/541)). Otherwise, set the `DOCKER_DEFAULT_PLATFORM` environmental variable to `linux/amd64` to build `x86_64` packages.
 
 #### Cloud9 setup (optional)
 
-1. Follow the steps on https://docs.aws.amazon.com/cloud9/latest/user-guide/setting-up.html
-2. Resize the EBS volume to 40 Gb, by following the steps on https://docs.aws.amazon.com/cloud9/latest/user-guide/move-environment.html#move-environment-resize
+1. Follow the steps on [https://docs.aws.amazon.com/cloud9/latest/user-guide/setting-up.html](https://docs.aws.amazon.com/cloud9/latest/user-guide/setting-up.html)
+2. Resize the EBS volume to 40 Gb, by following the steps on [https://docs.aws.amazon.com/cloud9/latest/user-guide/move-environment.html#move-environment-resize](https://docs.aws.amazon.com/cloud9/latest/user-guide/move-environment.html#move-environment-resize)
 3. Download the artifacts in the Cloud9 environment
 4. Proceed with the steps below
 
@@ -32,80 +32,83 @@ With all installed, run this command:
 
 ```shell
 $ python3 -V && cdk --version && docker info -f "{{.OperatingSystem}}"
-```
-
-An output similar to the following indicates that all is ok to proceed:
-
-```shell
 Python 3.12.2
 2.135.0 (build d46c474)
 Docker Desktop
 ```
 
-If any of these commands fails, you can revisit the documentation and check for possible steps you have forgotten to complete. 
+An output similar to the above indicates that all is ok to proceed.
+
+If any of these commands fails, you can revisit the documentation and check for possible steps you have forgotten to complete.
 Ensure that your CDK version is using CDK V2, by checking if the second line of the output follows the pattern 2.*.*.
 
 Having those installed, it is time to configure your environment to connect to your AWS Account.
-To set up your local environment to use such an AWS account you can follow the steps described at 
-https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html} 
+To set up your local environment to use such an AWS account you can follow the steps described at [https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
 
 #### Create Python virtual environment
 
 To manually create a virtualenv on MacOS and Linux:
 
 ```shell
-$ python3 -m venv .venv
+python3 -m venv .venv
 ```
 
 After the init process completes and the virtualenv is created, you can use the following
 step to activate your virtualenv.
 
 ```shell
-$ source .venv/bin/activate
+source .venv/bin/activate
 ```
 
 If you are a Windows platform, you would activate the virtualenv like this:
 
 ```shell
-% .venv\Scripts\activate.bat
+.venv\Scripts\activate.bat
 ```
 
 Once the virtualenv is activated, you can install the required dependencies.
 
 ```shell
-$ pip install -r requirements.txt
+pip install -r requirements.txt
 ```
 
 #### Bootstrap CDK
 
 Run the following
-```
-$ cdk bootstrap
+
+```shell
+cdk bootstrap
 ```
 
 #### Deployment
 
-
 1. Run AWS CDK Toolkit to deploy the Backend stack with the runtime resources.
-    ```shell
-    $ cdk deploy --require-approval=never
-    ```
-2. Any modifications made to the code can be applied to the deployed stack by running the same command again.
-    ```shell
-    $ cdk deploy --require-approval=never
-    ```
-   
-### Populate Guidelines table
 
-Once the Stack is setup, you need to populate the DynamoDB Guidelines table with the data from the Guidelines Excel sheet 
-that is included in the `guidelines` folder
+    ```shell
+    cdk deploy --require-approval=never
+    ```
+
+    > Use `DOCKER_DEFAULT_PLATFORM=linux/amd64 cdk deploy --require-approval=never` on macOS
+
+2. Any modifications made to the code can be applied to the deployed stack by running the same command again.
+
+    ```shell
+    cdk deploy --require-approval=never
+    ```
+
+    > Use `DOCKER_DEFAULT_PLATFORM=linux/amd64 cdk deploy --require-approval=never` on macOS
+
+#### Populate Guidelines table
+
+Once the Stack is setup, you need to populate the DynamoDB Guidelines table with the data from the Guidelines Excel sheet that is included in the `guidelines` folder.
 
 At the `scripts` folder, run the following script to populate the Guidelines table
+
 ```shell
-$ python load_guidelines.py  --guidelines_file_path ../guidelines/guidelines_example.xlsx
+python load_guidelines.py  --guidelines_file_path ../guidelines/guidelines_example.xlsx
 ```
 
-### Add users to Cognito User Pool
+#### Add users to Cognito User Pool
 
 First, locate the Cognito User Pool ID, through the AWS CLI:
 
@@ -119,7 +122,7 @@ $ aws cloudformation describe-stacks --stack-name MainBackendStack --query "Stac
 
 You can then go the Amazon Cognito page at the AWS Console, search for the User Pool and add users
 
-### Enable access to Bedrock models
+#### Enable access to Bedrock models
 
 Models are not enabled by default on Amazon Bedrock, so if this is the first time you are going to use Amazon Bedrock, 
 it is recommended to first check if the access is already enabled.
@@ -134,26 +137,30 @@ Click the **Enable specific models** button and enable the checkbox for Anthropi
 
 Click **Next** and **Submit** buttons
 
-
 ## How to customize contract analysis accordding to your use case  
 
-This solution was designed to support analysis of contracts of different types and of different languages, based on the assumption that the contracts establish an agreement between two parties: a given company and another party. The solution already comes pre-configured to analyze service contract contracts in English for the company *AnyCompany*, together with an example of guidelines.    
+This solution was designed to support analysis of contracts of different types and of different languages, based on the assumption that the contracts establish an agreement between two parties: a given company and another party. The solution already comes pre-configured to analyze service contract contracts in English for the company *AnyCompany*, together with an example of guidelines.
 
 The customization of the contract analysis according to your specific use case basically comprises two major configuration artifacts:
+
 - The App Properties. It's a YAML file that defines the service contract type, the language, the customer name and the role setting for two parties in the agreement. It's passed to scripts under `scripts` folder and to the CloudFormation resources via the `cdk deploy` command. You can either configure the existing *app_properties.yaml* located at the root folder, or you can create a new file - for the latter, you'd need to send an extra parameter to each script/command that depends on the App properties.
-- The guidelines. It's an Excel worksheet defining the taxonomy of clause types and how to classify and evaluate the contract clauses. The `guidelines_example.xslx` is your fastest reference defining your guidelines. 
+- The guidelines. It's an Excel worksheet defining the taxonomy of clause types and how to classify and evaluate the contract clauses. The `guidelines_example.xslx` is your fastest reference defining your guidelines.
 
 The recommended sequence of steps:
-1. Customize App Properties. 
-2. Deploy the Backend stack again. 
+
+1. Customize App Properties.
+2. Deploy the Backend stack again.
 3. Create a custom guidelines worksheet. Using the example worksheet (`guidelines_example.xslx`) as reference, you can create your own, preserving the same tab/column naming. Apart from what is defined in the example in terms of naming, you can create additional tabs/columns. The content of each column can be in any language that is supported by Anthropic Claude model - just make sure the content language is same as the `language` value defined in the App Properties.
 4. Generate evaluation questions for the guidelines. From the `scripts` folder:
-```shell
-$ python generate_evaluation_questions.py --guidelines_file_path <custom_guidelines_file_path>
-```
+
+    ```shell
+    $ python generate_evaluation_questions.py --guidelines_file_path <custom_guidelines_file_path>
+    ```
+
 5. Open the resulting `evaluation_questions.xslx` folder and do your own curation. The file content was generated by a Large Language Model as an attempt to produce a set of binary questions (that are answered as 'Yes'/'No') to evaluate the compliance of each contract clause, but that is not authoritative, so you are recommended to go over the results and complement, correct, remove the existing content and also add your own set of binary questions.
 6. Bring your curated set of evaluation questions to your custom guidelines worksheet: at the `Taxonomy` tab --> `Evaluation Questions` column
 7. Load the custom guidelines into DynamoDB. From the `scripts` folder:
-```shell
-$ python load_guidelines.py --guidelines_file_path <custom_guidelines_file_path>
-```
+
+    ```shell
+    python load_guidelines.py --guidelines_file_path <custom_guidelines_file_path>
+    ```


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/generative-ai-cdk-constructs/issues/541

*Description of changes:*
Document how to build on non-x86 for the contract analysis using LangChain common dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
