### PR TITLE
fix: bucket arn

### DIFF
--- a/samples/sagemaker_huggingface_model_svd/README.md
+++ b/samples/sagemaker_huggingface_model_svd/README.md
@@ -88,10 +88,13 @@ This project is built using the [AWS Cloud Development Kit (CDK)](https://aws.am
    npm install
    ```
 
-5. Update the location of your model artifacts. First, update in [sagemaker_huggingface_model_svd-stack.ts](./lib/sagemaker_huggingface_model_svd-stack.ts) the field ```modelDataUrl``` to specify the location where your saved your model artifacts during the [prepare your model](#prepare-your-model) step. Next, replace the bucket name field (```BUCKET_NAME```) in the same file with the name of the Amazon S3 bucket containing your model artifacts. This will give the permissions to the construct to pull your model artifacts. Specify the ```outputPath``` and ```failure``` folder paths where the construct will output the model response. Those folders need to be in the same bucket specified previously. For instance:
+5. Update the location of your model artifacts. First, update in [sagemaker_huggingface_model_svd-stack.ts](./lib/sagemaker_huggingface_model_svd-stack.ts) the field ```modelDataUrl``` to specify the location where your saved your model artifacts during the [prepare your model](#prepare-your-model) step. First, replace the bucket name field (```BUCKET_NAME```) and potentially the bucket key (```BUCKET_KEY```) in the same file with the name of the Amazon S3 bucket containing your model artifacts. This will give the permissions to the construct to pull your model artifacts. Specify the ```outputPath``` and ```failure``` folder paths where the construct will output the model response. Those folders need to be in the same bucket specified previously. For instance:
 
 ```
 const BUCKET_NAME = 'sagemaker-us-east-1-XXXXXXXX'
+const BUCKET_KEY = 'svd-hf-1';
+const BUCKET_PATH = `s3://${BUCKET_NAME}/${BUCKET_KEY}`
+const BUCKET_ARN = `arn:aws:s3:::${BUCKET_NAME}`
 ...
 modelDataUrl: BUCKET_PATH+'/model.tar.gz',
 ...

--- a/samples/sagemaker_huggingface_model_svd/README.md
+++ b/samples/sagemaker_huggingface_model_svd/README.md
@@ -88,7 +88,7 @@ This project is built using the [AWS Cloud Development Kit (CDK)](https://aws.am
    npm install
    ```
 
-5. Update the location of your model artifacts. First, update in [sagemaker_huggingface_model_svd-stack.ts](./lib/sagemaker_huggingface_model_svd-stack.ts) the field ```modelDataUrl``` to specify the location where your saved your model artifacts during the [prepare your model](#prepare-your-model) step. First, replace the bucket name field (```BUCKET_NAME```) and potentially the bucket key (```BUCKET_KEY```) in the same file with the name of the Amazon S3 bucket containing your model artifacts. This will give the permissions to the construct to pull your model artifacts. Specify the ```outputPath``` and ```failure``` folder paths where the construct will output the model response. Those folders need to be in the same bucket specified previously. For instance:
+5. Update the location of your model artifacts. First, update in [sagemaker_huggingface_model_svd-stack.ts](./lib/sagemaker_huggingface_model_svd-stack.ts) the field ```modelDataUrl``` to specify the location where your saved your model artifacts during the [prepare your model](#prepare-your-model) step. Next, replace the bucket name field (```BUCKET_NAME```) and potentially the bucket key (```BUCKET_KEY```) in the same file with the name of the Amazon S3 bucket containing your model artifacts. This will give the permissions to the construct to pull your model artifacts. Specify the ```outputPath``` and ```failure``` folder paths where the construct will output the model response. Those folders need to be in the same bucket specified previously. For instance:
 
 ```
 const BUCKET_NAME = 'sagemaker-us-east-1-XXXXXXXX'

--- a/samples/sagemaker_huggingface_model_svd/README.md
+++ b/samples/sagemaker_huggingface_model_svd/README.md
@@ -88,10 +88,10 @@ This project is built using the [AWS Cloud Development Kit (CDK)](https://aws.am
    npm install
    ```
 
-5. Update the location of your model artifacts. Update in [sagemaker_huggingface_model_svd-stack.ts](./lib/sagemaker_huggingface_model_svd-stack.ts) the field ```modelDataUrl``` to specify the location where your saved your model artifacts during the [prepare your model](#prepare-your-model) step. The field should look like this: ```s3//BUCKET//KEY```. Also, replace the bucket arn field (```BUCKET_ARN```) in the same file with the ARN of the Amazon S3 bucket containing your model artifacts. This will give the permissions to the construct to pull your model artifacts. Specify the ```outputPath``` and ```failure``` folder paths where the construct will output the model response. Those folders need to be in the same bucket specified previously. For instance:
+5. Update the location of your model artifacts. First, update in [sagemaker_huggingface_model_svd-stack.ts](./lib/sagemaker_huggingface_model_svd-stack.ts) the field ```modelDataUrl``` to specify the location where your saved your model artifacts during the [prepare your model](#prepare-your-model) step. Next, replace the bucket name field (```BUCKET_NAME```) in the same file with the name of the Amazon S3 bucket containing your model artifacts. This will give the permissions to the construct to pull your model artifacts. Specify the ```outputPath``` and ```failure``` folder paths where the construct will output the model response. Those folders need to be in the same bucket specified previously. For instance:
 
 ```
-const BUCKET_PATH = 's3://sagemaker-us-east-1-XXXXXXXX/svd-hf-1'
+const BUCKET_NAME = 'sagemaker-us-east-1-XXXXXXXX'
 ...
 modelDataUrl: BUCKET_PATH+'/model.tar.gz',
 ...

--- a/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
+++ b/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
@@ -21,9 +21,13 @@ export class SagemakerHuggingfaceModelSvdStack extends cdk.Stack {
     super(scope, id, props);
 
     // Define some constants
+    const BUCKET_NAME = 'XXXXXXXXXXX';
     const SG_ENDPOINT_NAME = 'svdendpoint';
     const HUGGING_FACE_MODEL_ID = 'stabilityai/stable-video-diffusion-img2vid-xt-1-1';
-    const BUCKET_PATH = 's3://BUCKET'
+    const BUCKET_PATH = `s3://${BUCKET_NAME}/svd-hf-1`
+    const BUCKET_ARN = `arn:aws:s3:::${BUCKET_NAME}`
+
+    // S3 bucket for storing model artifacts
 
     // Custom Sagemaker Endpoint construct
     const CustomHuggingFaceEndpoint = new genai.CustomSageMakerEndpoint(this, 'testsvdendpoint', {
@@ -62,8 +66,8 @@ export class SagemakerHuggingfaceModelSvdStack extends cdk.Stack {
           's3:List*',
         ],
         resources: [
-          'BUCKET_ARN',
-          'BUCKET_ARN/*',
+          `${BUCKET_ARN}`,
+          `${BUCKET_ARN}/*`,
         ],
       }),
     );

--- a/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
+++ b/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
@@ -27,8 +27,6 @@ export class SagemakerHuggingfaceModelSvdStack extends cdk.Stack {
     const BUCKET_PATH = `s3://${BUCKET_NAME}/svd-hf-1`
     const BUCKET_ARN = `arn:aws:s3:::${BUCKET_NAME}`
 
-    // S3 bucket for storing model artifacts
-
     // Custom Sagemaker Endpoint construct
     const CustomHuggingFaceEndpoint = new genai.CustomSageMakerEndpoint(this, 'testsvdendpoint', {
       modelId: HUGGING_FACE_MODEL_ID,

--- a/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
+++ b/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
@@ -21,12 +21,13 @@ export class SagemakerHuggingfaceModelSvdStack extends cdk.Stack {
     super(scope, id, props);
 
     // Define some constants
-    const BUCKET_NAME = 'XXXXXXXXXXX';
+    const BUCKET_NAME = 'sagemaker-us-east-1-XXXXXXXX';
     const BUCKET_KEY = 'svd-hf-1';
-    const SG_ENDPOINT_NAME = 'svdendpoint';
-    const HUGGING_FACE_MODEL_ID = 'stabilityai/stable-video-diffusion-img2vid-xt-1-1';
     const BUCKET_PATH = `s3://${BUCKET_NAME}/${BUCKET_KEY}`
     const BUCKET_ARN = `arn:aws:s3:::${BUCKET_NAME}`
+    const SG_ENDPOINT_NAME = 'svdendpoint';
+    const HUGGING_FACE_MODEL_ID = 'stabilityai/stable-video-diffusion-img2vid-xt-1-1';
+
 
     // Custom Sagemaker Endpoint construct
     const CustomHuggingFaceEndpoint = new genai.CustomSageMakerEndpoint(this, 'testsvdendpoint', {

--- a/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
+++ b/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
@@ -22,9 +22,10 @@ export class SagemakerHuggingfaceModelSvdStack extends cdk.Stack {
 
     // Define some constants
     const BUCKET_NAME = 'XXXXXXXXXXX';
+    const BUCKET_KEY = 'svd-hf-1';
     const SG_ENDPOINT_NAME = 'svdendpoint';
     const HUGGING_FACE_MODEL_ID = 'stabilityai/stable-video-diffusion-img2vid-xt-1-1';
-    const BUCKET_PATH = `s3://${BUCKET_NAME}/svd-hf-1`
+    const BUCKET_PATH = `s3://${BUCKET_NAME}/${BUCKET_KEY}`
     const BUCKET_ARN = `arn:aws:s3:::${BUCKET_NAME}`
 
     // Custom Sagemaker Endpoint construct

--- a/samples/sagemaker_huggingface_model_svd/model_testing/model_testing.py
+++ b/samples/sagemaker_huggingface_model_svd/model_testing/model_testing.py
@@ -25,7 +25,7 @@ s3_resource = boto3.resource("s3")
 sagemaker_client = boto3.client("sagemaker-runtime")
 
 # Configuration
-S3_BUCKET = "sagemaker-us-east-1-713520743023"
+S3_BUCKET = "XXXXX"
 S3_BUCKET_KEY = "svd-hf-1"
 S3_BUCKET_OUTPUT_KEY = "output" # this is the output folder in the S3 bucket (configured in the asyncInference construct settings)
 ENDPOINT_NAME = "svdendpoint" # endpoint name configured in the construct

--- a/samples/sagemaker_huggingface_model_svd/model_testing/model_testing.py
+++ b/samples/sagemaker_huggingface_model_svd/model_testing/model_testing.py
@@ -25,7 +25,7 @@ s3_resource = boto3.resource("s3")
 sagemaker_client = boto3.client("sagemaker-runtime")
 
 # Configuration
-S3_BUCKET = "XXXXX"
+S3_BUCKET = "sagemaker-us-east-1-713520743023"
 S3_BUCKET_KEY = "svd-hf-1"
 S3_BUCKET_OUTPUT_KEY = "output" # this is the output folder in the S3 bucket (configured in the asyncInference construct settings)
 ENDPOINT_NAME = "svdendpoint" # endpoint name configured in the construct


### PR DESCRIPTION
The `BUCKET_ARN` was a string.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
