### PR TITLE
feat(sampleapps): fixed content gen and doc explorer

### DIFF
--- a/samples/content-generation/README.md
+++ b/samples/content-generation/README.md
@@ -114,7 +114,7 @@ IDENTITY_POOL_ID="<IdentityPoolId>"
 APP_URI="http://localhost:8501/"
 AUTHENTICATED_ROLE_ARN="<AuthenticatedRoleArn>"
 GRAPHQL_ENDPOINT = "<GraphQLEndpoint>"
-S3_PROCESSED_BUCKET = "<generatedAssetsBucket>"
+S3_GENERATED_BUCKET = "<generatedAssetsBucket>"
 
 ```
 

--- a/samples/content-generation/client_app/requirements.txt
+++ b/samples/content-generation/client_app/requirements.txt
@@ -6,3 +6,4 @@ requests==2.32.2
 requests-aws4auth==1.2.3
 streamlit==1.38.0
 st_pages==1.0.1
+websocket-client==1.7.0

--- a/samples/document_explorer/client_app/Home.py
+++ b/samples/document_explorer/client_app/Home.py
@@ -14,64 +14,89 @@
 import streamlit as st
 # Local imports
 from common.cognito_helper import CognitoHelper
-from common.streamlit_utils import hide_deploy_button
-from streamlit_option_menu import option_menu
+from st_pages import  get_nav_from_toml
 
-from st_pages import show_pages,Section, Page, hide_pages,add_indentation
+from common.streamlit_utils import hide_deploy_button
+#from streamlit_option_menu import option_menu
+
+#from st_pages import show_pages,Section, Page, hide_pages,add_indentation
 
 
 #========================================================================================
 # [View] Render UI components  
 #========================================================================================
 # Streamlit page configuration
-st.set_page_config(page_title="Generative AI CDK Constructs Samples", page_icon="🤖")
-add_indentation() 
+# st.set_page_config(page_title="Generative AI CDK Constructs Samples", page_icon="🤖")
+# add_indentation() 
 
-show_pages(
-    [
-        Section("Document Explorer", icon="📁"),
-        Page("pages/1_doc_explorer_home.py", "Home", "🏠",in_section=True),
-        Page("pages/2_Select_Document.py", "Select Document", "📃",in_section=True),
-        Page("pages/3_Q&A.py", "Q&A", "💬",in_section=True),
-        Page("pages/4_Summary.py", "Summary", "🏷️",in_section=True),
-        Page("pages/5_Visual_Q&A.py", "Visual Q&A", "👁️‍🗨️",in_section=True),
+# show_pages(
+#     [
+#         Section("Document Explorer", icon="📁"),
+#         Page("pages/1_doc_explorer_home.py", "Home", "🏠",in_section=True),
+#         Page("pages/2_Select_Document.py", "Select Document", "📃",in_section=True),
+#         Page("pages/3_Q&A.py", "Q&A", "💬",in_section=True),
+#         Page("pages/4_Summary.py", "Summary", "🏷️",in_section=True),
+#         Page("pages/5_Visual_Q&A.py", "Visual Q&A", "👁️‍🗨️",in_section=True),
         
-    ]
-)
+#     ]
+# )
 
-#with st.sidebar:
-# Check if user is authenticated and display login/logout buttons
+# #with st.sidebar:
+# # Check if user is authenticated and display login/logout buttons
+# auth = CognitoHelper() 
+# auth.set_session_state()
+# auth.print_login_logout_buttons()
+
+# if auth.is_authenticated():
+   
+        
+#         #hide_deploy_button()
+
+#         # Guest user UI 
+#         st.write("# Welcome to Document Explorer!")
+#         st.markdown('''
+#         The Sample Generative AI Application demonstrates how to build end-to-end solutions leveraging AWS services and the [Generative AI Constructs library](https://github.com/awslabs/generative-ai-cdk-constructs).
+
+#         It includes examples of key components needed in generative AI applications:
+
+#         - [Data Ingestion Pipeline](https://github.com/awslabs/generative-ai-cdk-constructs/tree/main/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch): Ingests documents, converts them to text, and stores them in a knowledge base for retrieval. This enables long context window approaches.
+
+#         - [Document Summarization](https://github.com/awslabs/generative-ai-cdk-constructs/tree/main/src/patterns/gen-ai/aws-summarization-appsync-stepfn): Summarizes PDF documents leveraging Large Language Models like Anthropic Claude V2 via Amazon Bedrock. 
+
+#         - [Question Answering](https://github.com/awslabs/generative-ai-cdk-constructs/tree/main/src/patterns/gen-ai/aws-qa-appsync-opensearch): Answers natural language questions by retrieving relevant documents from the knowledge base and leveraging Large Language Models.
+
+#         By providing reusable constructs following AWS best practices, this app enables quickly building custom generative AI apps on AWS. The constructs abstract complexity of orchestrating AWS services like Lambda, OpenSearch, Step Functions, Bedrock, etc.
+
+#         Here is the architecture diagram of the sample application:
+#         ''')
+#         st.image('assets/doc_explorer_diagram.png', width=700)
+#         st.markdown('<style>div[class="stApp"] > div[class="css-1es6loc e1tzin5j2"]{text-align:center;}</style>', unsafe_allow_html=True)
+
+
+      
+# else:
+#     #hide_pages(["Q&A","Select Document","Summary","Visual Q&A"])
+#     st.write("Please login!")
+#     st.stop()
+
+st.set_page_config(
+    page_title="Generative AI CDK Constructs Samples", page_icon="🤖")
+
+#sections = st.sidebar.toggle("Sections", value=True, key="use_sections")
+
+nav = get_nav_from_toml(
+    "pages/pages_sections.toml" 
+)
+pg = st.navigation(nav)
+pg.run()
+
 auth = CognitoHelper() 
 auth.set_session_state()
 auth.print_login_logout_buttons()
 
 if auth.is_authenticated():
-   
+        
         hide_deploy_button()
-
-        # Guest user UI 
-        st.write("# Welcome to Document Explorer!")
-        st.markdown('''
-        The Sample Generative AI Application demonstrates how to build end-to-end solutions leveraging AWS services and the [Generative AI Constructs library](https://github.com/awslabs/generative-ai-cdk-constructs).
-
-        It includes examples of key components needed in generative AI applications:
-
-        - [Data Ingestion Pipeline](https://github.com/awslabs/generative-ai-cdk-constructs/tree/main/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch): Ingests documents, converts them to text, and stores them in a knowledge base for retrieval. This enables long context window approaches.
-
-        - [Document Summarization](https://github.com/awslabs/generative-ai-cdk-constructs/tree/main/src/patterns/gen-ai/aws-summarization-appsync-stepfn): Summarizes PDF documents leveraging Large Language Models like Anthropic Claude V2 via Amazon Bedrock. 
-
-        - [Question Answering](https://github.com/awslabs/generative-ai-cdk-constructs/tree/main/src/patterns/gen-ai/aws-qa-appsync-opensearch): Answers natural language questions by retrieving relevant documents from the knowledge base and leveraging Large Language Models.
-
-        By providing reusable constructs following AWS best practices, this app enables quickly building custom generative AI apps on AWS. The constructs abstract complexity of orchestrating AWS services like Lambda, OpenSearch, Step Functions, Bedrock, etc.
-
-        Here is the architecture diagram of the sample application:
-        ''')
-        st.image('assets/doc_explorer_diagram.png', width=700)
-        st.markdown('<style>div[class="stApp"] > div[class="css-1es6loc e1tzin5j2"]{text-align:center;}</style>', unsafe_allow_html=True)
-
-
-      
 else:
-    hide_pages(["Q&A","Select Document","Summary","Visual Q&A"])
-    st.write("Please login!")
+    st.info("Please login!")
     st.stop()

--- a/samples/document_explorer/client_app/pages/1_doc_explorer_home.py
+++ b/samples/document_explorer/client_app/pages/1_doc_explorer_home.py
@@ -14,10 +14,10 @@
 import streamlit as st
 # Local imports
 from common.cognito_helper import CognitoHelper
-from common.streamlit_utils import hide_deploy_button
-from streamlit_option_menu import option_menu
+# from common.streamlit_utils import hide_deploy_button
+# from streamlit_option_menu import option_menu
 
-from st_pages import show_pages,Section, Page, hide_pages,add_indentation
+# from st_pages import show_pages,Section, Page, hide_pages,add_indentation
 
 
 #========================================================================================
@@ -25,7 +25,7 @@ from st_pages import show_pages,Section, Page, hide_pages,add_indentation
 #========================================================================================
 # Streamlit page configuration
 #pages = ["1_📁_Select_Document", "2_🏷️_Summary", "3_💬_Q&A","4_:camera:_Image_Generation"]
-add_indentation() 
+#add_indentation() 
 
 #with st.sidebar:
 # Check if user is authenticated and display login/logout buttons
@@ -36,7 +36,7 @@ auth.print_login_logout_buttons()
 if auth.is_authenticated():
    
        
-        hide_deploy_button()
+        #hide_deploy_button()
 
         # Guest user UI 
         st.write("# Welcome to Document Explorer!")

--- a/samples/document_explorer/client_app/pages/2_Select_Document.py
+++ b/samples/document_explorer/client_app/pages/2_Select_Document.py
@@ -28,9 +28,9 @@ from graphql.graphql_mutation_client import GraphQLMutationClient
 from graphql.graphql_subscription_client import GraphQLSubscriptionClient
 from graphql.mutations import Mutations
 from graphql.subscriptions import Subscriptions
-from streamlit_option_menu import option_menu
-from st_pages import show_pages,Section, Page, hide_pages,add_indentation
-from streamlit_extras.switch_page_button import switch_page
+#from streamlit_option_menu import option_menu
+#from st_pages import show_pages,Section, Page, hide_pages,add_indentation
+#from streamlit_extras.switch_page_button import switch_page
 
 
 #========================================================================================
@@ -233,10 +233,10 @@ def to_tuple(s3_object):
 
 # Streamlit page configuration
 
-st.set_page_config(page_title="Select Document",
-                    page_icon="📁",layout="wide",
-                    initial_sidebar_state="expanded",)
-add_indentation() 
+# st.set_page_config(page_title="Select Document",
+#                     page_icon="📁",layout="wide",
+#                     initial_sidebar_state="expanded",)
+# add_indentation() 
 
 
 st.session_state['selected_nav_index']=0
@@ -249,7 +249,7 @@ else:
 
     
 
-hide_deploy_button()
+#hide_deploy_button()
 
 
 

--- a/samples/document_explorer/client_app/pages/3_Q&A.py
+++ b/samples/document_explorer/client_app/pages/3_Q&A.py
@@ -24,9 +24,7 @@ from graphql.graphql_mutation_client import GraphQLMutationClient
 from graphql.graphql_subscription_client import GraphQLSubscriptionClient
 from graphql.mutations import Mutations
 from graphql.subscriptions import Subscriptions
-from streamlit_option_menu import option_menu
-from st_pages import show_pages,Section, Page, hide_pages,add_indentation
-from streamlit_extras.switch_page_button import switch_page
+# 
 
 #========================================================================================
 # [Model] Load configuration and environment variables
@@ -186,11 +184,11 @@ def subscribe_to_answering_updates():
 #========================================================================================
 # Streamlit page configuration
 
-st.set_page_config(page_title="Q&A", page_icon="💬", layout="wide") 
-add_indentation() 
+# st.set_page_config(page_title="Q&A", page_icon="💬", layout="wide") 
+# add_indentation() 
 
 
-hide_deploy_button()
+# hide_deploy_button()
 
 # Check if user is authenticated and display login/logout buttons
 auth = CognitoHelper() 

--- a/samples/document_explorer/client_app/pages/4_Summary.py
+++ b/samples/document_explorer/client_app/pages/4_Summary.py
@@ -26,9 +26,9 @@ from graphql.graphql_mutation_client import GraphQLMutationClient
 from graphql.graphql_subscription_client import GraphQLSubscriptionClient
 from graphql.mutations import Mutations
 from graphql.subscriptions import Subscriptions
-from streamlit_option_menu import option_menu
-from st_pages import show_pages,Section, Page, hide_pages,add_indentation
-from streamlit_extras.switch_page_button import switch_page
+# from streamlit_option_menu import option_menu
+# from st_pages import show_pages,Section, Page, hide_pages,add_indentation
+# from streamlit_extras.switch_page_button import switch_page
 
 #========================================================================================
 # [Model] Load configuration and environment variables
@@ -206,10 +206,10 @@ def display_image(key):
 
 # Streamlit page configuration
 
-st.set_page_config(page_title="Summary", page_icon="🏷️", layout="wide", initial_sidebar_state="expanded")
-add_indentation() 
+# st.set_page_config(page_title="Summary", page_icon="🏷️", layout="wide", initial_sidebar_state="expanded")
+# add_indentation() 
 
-hide_deploy_button()
+# hide_deploy_button()
 
 # Check if user is authenticated and display login/logout buttons
 auth = CognitoHelper() 
@@ -245,8 +245,10 @@ if auth.is_authenticated() and selected_file:
 
         with col2:
             # Display summary widget
-            text_width = int(st_javascript("window.innerWidth", key="text_width") - 20)
-            text_height = int(text_width * 3/4)
+            # Use these dimensions for the summary widget
+           
+            text_width = pdf_width
+            text_height = pdf_height + 10
 
             summary_widget = st.empty()
             if('file_processed' not in st.session_state): 
@@ -258,7 +260,8 @@ if auth.is_authenticated() and selected_file:
                 summary_widget.text_area(f"Summary for **{selected_file}**", height=text_height)
                 st.session_state['summary_widget'] = summary_widget
                 st.session_state['summary_widget_height'] = text_height
-                
+
+
             if st.button("Generate Summary",type="primary"):
                 with st.spinner('Processing...'):
                     if (st.session_state['file_processed']==selected_file):

--- a/samples/document_explorer/client_app/pages/5_Visual_Q&A.py
+++ b/samples/document_explorer/client_app/pages/5_Visual_Q&A.py
@@ -27,9 +27,9 @@ from graphql.graphql_subscription_client import GraphQLSubscriptionClient
 from graphql.mutations import Mutations
 from graphql.subscriptions import Subscriptions
 import boto3
-from streamlit_option_menu import option_menu
-from st_pages import show_pages,Section, Page, hide_pages,add_indentation
-from streamlit_extras.switch_page_button import switch_page
+# from streamlit_option_menu import option_menu
+# from st_pages import show_pages,Section, Page, hide_pages,add_indentation
+# from streamlit_extras.switch_page_button import switch_page
 
 #========================================================================================
 # [Model] Load configuration and environment variables
@@ -224,12 +224,12 @@ def subscribe_to_answering_updates():
 #========================================================================================
 # Streamlit page configuration
 
-st.set_page_config(page_title="Q&A", page_icon="💬", layout="wide",initial_sidebar_state="expanded") 
-add_indentation() 
-st.session_state['selected_nav_index']=0
+# st.set_page_config(page_title="Q&A", page_icon="💬", layout="wide",initial_sidebar_state="expanded") 
+# add_indentation() 
+# st.session_state['selected_nav_index']=0
 
 
-hide_deploy_button()
+# hide_deploy_button()
 
 # Check if user is authenticated and display login/logout buttons
 auth = CognitoHelper() 

--- a/samples/document_explorer/client_app/pages/pages_sections.toml
+++ b/samples/document_explorer/client_app/pages/pages_sections.toml
@@ -1,0 +1,30 @@
+[[pages]]
+name = "Document Explorer"
+icon = "📁"
+is_section = true
+
+[[pages]]
+path = "pages/1_doc_explorer_home.py"
+name = "Home"
+icon = "🏠"
+
+
+[[pages]]
+path = "pages/2_Select_Document.py"
+name = "Select Document"
+icon = "📃"
+
+[[pages]]
+path = "pages/3_Q&A.py"
+name = "Q&A"
+icon = "💬"
+
+[[pages]]
+path = "pages/4_Summary.py"
+name = "Summary"
+icon = "🏷️"
+
+[[pages]]
+path = "pages/5_Visual_Q&A.py"
+name = "Visual Q&A"
+icon = "👁️‍🗨️"

--- a/samples/document_explorer/client_app/requirements.txt
+++ b/samples/document_explorer/client_app/requirements.txt
@@ -4,10 +4,9 @@ PyJWT==2.8.0
 python-dotenv==1.0.1
 requests==2.32.0
 requests-aws4auth==1.2.3
-streamlit-option-menu
+streamlit==1.38.0
+websocket-client==1.7.0
+st_pages==1.0.1
 streamlit-aggrid==0.3.4.post3
 streamlit-javascript==0.1.5
-streamlit==1.30.0
-websocket-client==1.7.0
-st_pages==0.4.5
-streamlit_extras==0.4.0
+


### PR DESCRIPTION
*Issue #, if available:*

Added websocket-client dependency on client_app.
Upgraded streamlit version to 1.38.0 for doc explorer sample.
Updated streamlit summary text area width and height

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
