### PR TITLE
Fix: Deployment to non-default region, Missing variables in .env, SQL lambda port fix for security group

### DIFF
--- a/samples/text-to-sql/README.md
+++ b/samples/text-to-sql/README.md
@@ -212,7 +212,7 @@ Still within the /client_app directory, create an ```.env``` file with the follo
 
 ```
 COGNITO_DOMAIN="<TextToSqlStack.CognitoDomain>"
-REGION="<TextToSqlStack.Region>"
+REGION="<TextToSqlStack.REGION>"
 USER_POOL_ID="<TextToSqlStack.UserPoolId>"
 CLIENT_ID="<TextToSqlStack.ClientId>"
 CLIENT_SECRET="COGNITO_CLIENT_SECRET"
@@ -223,7 +223,7 @@ FEEDBACK_QUEUE ="<TextToSqlStack.FEEDBACK_QUEUE>"
 RESULT_QUEUE = "<TextToSqlStack.RESULT_QUEUE>"
 FEEDBACK_ENDPOINT="<TextToSqlStack.FEEDBACK_ENDPOINT>"
 CONFIG_BUCKET="<TextToSqlStack.CONFIG_BUCKET>"
-
+API_ENDPOINT="<TextToSqlStack.API_ENDPOINT>"
 ```
 
 Note: The ```COGNITO_CLIENT_SECRET``` is a secret value that can be retrieved from the AWS Console. Go to the [Amazon Cognito page](https://console.aws.amazon.com/cognito/home) in the AWS console, then select the created user pool. Under App integration, select App client settings. Then, select Show Details and copy the value of the App client secret.

--- a/samples/text-to-sql/README.md
+++ b/samples/text-to-sql/README.md
@@ -194,7 +194,7 @@ SHOW TABLES;
   and expected query. This is used by the LLM to generate accurate query.
 
 ```cd text-to-sql
-aws s3 cp ./config_files s3://config-bucket-name/ --recursive
+aws s3 cp ./config_files s3://config-bucket-name/config/ --recursive
 ```
 
 ## Run the Streamlit UI

--- a/samples/text-to-sql/client_app/pages/1_🤖_text_to_sql_client.py
+++ b/samples/text-to-sql/client_app/pages/1_🤖_text_to_sql_client.py
@@ -50,7 +50,7 @@ st.session_state["start_next_question"] = start_next_question
 reformulated_ques_key = "REFORMULATED_Q "
 generated_query_key = "GENERATED_Q "
 
-sqs = boto3.client('sqs')
+sqs = boto3.client('sqs', region_name=os.environ.get("REGION", "us-east-1"))
 # ========================================================================================
 # [Response]: Long Polling
 # ========================================================================================

--- a/samples/text-to-sql/lib/text-to-sql-stack.ts
+++ b/samples/text-to-sql/lib/text-to-sql-stack.ts
@@ -164,6 +164,7 @@ export class TextToSqlStack extends cdk.Stack {
       dbName: emergingTech.DbName.MYSQL,
       metadataSource: emergingTech.MetatdataSource.CONFIG_FILE,
       stage: stage,
+      dbPort: 3306
     });
 
     this.createAuroraCluster(
@@ -327,6 +328,10 @@ export class TextToSqlStack extends cdk.Stack {
     });
     new cdk.CfnOutput(this, "ClientId", {
       value: this.cognitoClient.userPoolClientId,
+    });
+
+    new cdk.CfnOutput(this, "REGION", {
+      value: Aws.REGION,
     });
 
     new cdk.CfnOutput(this, "AppUri", {


### PR DESCRIPTION
… query executor lambda security group port number fix to 3306

*Issue #, if available:*

*Description of changes:*
Fix: Deployment to non-default region, Missing variables in .env, SQL lambda port fix for security group

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
