### PR TITLE
feat(samples): Added SAES metric dashboard tag to samples

### DIFF
--- a/samples/content-generation/bin/content-generation.ts
+++ b/samples/content-generation/bin/content-generation.ts
@@ -18,7 +18,7 @@ const app = new cdk.App();
 new GenerateContentStack(app, 'GenerateContentStack', {
   natGateways: 1,
   clientUrl:env.clientUrl,
-  description: '(uksb-1tupboc43) Image generation stack',
+  description: '(uksb-1tupboc43) (tag: Image generation stack)',
 env: { account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION },
   /* If you don't specify 'env', this stack will be environment-agnostic.

--- a/samples/content-generation/bin/content-generation.ts
+++ b/samples/content-generation/bin/content-generation.ts
@@ -18,7 +18,7 @@ const app = new cdk.App();
 new GenerateContentStack(app, 'GenerateContentStack', {
   natGateways: 1,
   clientUrl:env.clientUrl,
-  description: '(uksb-1tupboc43) (tag: Image generation stack)',
+  //description: '(uksb-1tupboc43) (tag: Image generation stack)',
 env: { account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION },
   /* If you don't specify 'env', this stack will be environment-agnostic.

--- a/samples/content-generation/lib/content-generation-stack.ts
+++ b/samples/content-generation/lib/content-generation-stack.ts
@@ -30,6 +30,10 @@ export class GenerateContentStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: GenerateContentStackProps) {
     super(scope, id, props);
   
+    const key=  '(uksb-1tupboc43)'
+    const tag = ' Image generation stack'
+
+
     console.log(`Deploying to account ${this.account} in region ${this.region}`);
 
   //---------------------------------------------------------------------
@@ -246,6 +250,9 @@ export class GenerateContentStack extends cdk.Stack {
       existingGeneratedAssetsBucketObj: this.generatedAssetsBucket,
       observability: true,
     });
+
+    this.templateOptions.description = `Description: ${key}  (tag:${ tag}) `
+  
    
     NagSuppressions.addResourceSuppressions(grapdhQLApiRole, [{id: 'AwsSolutions-IAM5', reason: '* used after ARN prefix'}], true)
 

--- a/samples/contract-compliance-analysis/back-end/app.py
+++ b/samples/contract-compliance-analysis/back-end/app.py
@@ -25,7 +25,7 @@ app = cdk.App()
 stack_name = os.environ.get('STACK_NAME', "MainBackendStack")
 
 main_backend_stack = BackendStack(
-    app, stack_name, description=f'{(USAGE_METRIC)} (version:{VERSION}) (tag:{SOLUTION_NAME})'
+    app, stack_name, description=f'({USAGE_METRIC})(tag: {SOLUTION_NAME})'
 )
 
 cdk.Aspects.of(app).add(AwsSolutionsChecks())

--- a/samples/document_explorer/bin/document_explorer.ts
+++ b/samples/document_explorer/bin/document_explorer.ts
@@ -59,7 +59,6 @@ cdk.Tags.of(persistence).add("stack", "persistence");
 //-----------------------------------------------------------------------------
 const api = new ApiStack(app, 'ApiStack', {
   env: env,
-  description: '(uksb-1tupboc43) (tag: document explorer)',
   existingOpensearchServerlessCollection: persistence.opensearchCollection,
   existingVpc: network.vpc,
   existingSecurityGroup: network.securityGroups[0],

--- a/samples/document_explorer/bin/document_explorer.ts
+++ b/samples/document_explorer/bin/document_explorer.ts
@@ -59,7 +59,7 @@ cdk.Tags.of(persistence).add("stack", "persistence");
 //-----------------------------------------------------------------------------
 const api = new ApiStack(app, 'ApiStack', {
   env: env,
-  description: '(uksb-1tupboc43) API Layer stack',
+  description: '(uksb-1tupboc43) (tag: document explorer)',
   existingOpensearchServerlessCollection: persistence.opensearchCollection,
   existingVpc: network.vpc,
   existingSecurityGroup: network.securityGroups[0],

--- a/samples/document_explorer/lib/api-stack.ts
+++ b/samples/document_explorer/lib/api-stack.ts
@@ -271,6 +271,9 @@ export class ApiStack extends Stack {
         `${this.mergedApi.attrArn}/sourceApiAssociations/*`,
       ]
     }));
+
+    this.templateOptions.description = `Description: (uksb-1tupboc43) (tag: document explorer)`
+
     NagSuppressions.addResourceSuppressions(mergedApiRole, [{id: 'AwsSolutions-IAM5', reason: '* used after ARN prefix'}], true)
 
     // Add Source API

--- a/samples/documentation-Agent/lib/documentation-agent-stack.ts
+++ b/samples/documentation-Agent/lib/documentation-agent-stack.ts
@@ -1,0 +1,37 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as fs from 'fs';
+import * as path from 'path';
+import { bedrock } from '@cdklabs/generative-ai-cdk-constructs';
+
+
+export class DocumentationAgentStack extends cdk.Stack {
+  
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+     const key=  '(uksb-1tupboc43)'
+     const tag = ' Document Agent'
+     
+     // Read instruction from file
+     const instructionPath = path.join(__dirname, '..', 'instructions', 'readme-instructions.txt');
+     const instruction = fs.readFileSync(instructionPath, 'utf-8');
+ 
+
+     // print instruction
+     new cdk.CfnOutput(this, 'Instruction', {
+      value: instruction,
+      description: 'Instruction for the agent'
+    });
+    
+    const agent = new bedrock.Agent(this, 'documentationAgent', {
+      foundationModel: bedrock.BedrockFoundationModel.AMAZON_NOVA_MICRO_V1,
+      instruction: instruction,
+      enableUserInput: true,
+      shouldPrepareAgent:true
+    });
+    
+     this.templateOptions.description = `Description: ${key}  (tag:${ tag}) `
+  }
+}

--- a/samples/image-description/bin/image-description.ts
+++ b/samples/image-description/bin/image-description.ts
@@ -25,5 +25,5 @@ const imageDescStack = new ImageDescriptionStack(app, "ImageDesStack", {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
   },
-  description: "(uksb-1tupboc43) (tag: GenAI Image Description Stack)",
+  
 });

--- a/samples/image-description/bin/image-description.ts
+++ b/samples/image-description/bin/image-description.ts
@@ -25,5 +25,5 @@ const imageDescStack = new ImageDescriptionStack(app, "ImageDesStack", {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
   },
-  description: "(uksb-1tupboc43) GenAI Image Description Stack",
+  description: "(uksb-1tupboc43) (tag: GenAI Image Description Stack)",
 });

--- a/samples/image-description/lib/image-description-stack.ts
+++ b/samples/image-description/lib/image-description-stack.ts
@@ -140,6 +140,7 @@ export class ImageDescriptionStack extends cdk.Stack {
       }
     );
 
+    this.templateOptions.description =  "Description: (uksb-1tupboc43) (tag: Image Description sample)",
 
     summarization.inputAssetBucket.grantReadWrite(this.authenticatedRole);
     summarization.processedAssetBucket.grantRead(this.authenticatedRole);

--- a/samples/llamaindex-basic-data-loader/bin/llamaindex_basic_data_loader_stack.py
+++ b/samples/llamaindex-basic-data-loader/bin/llamaindex_basic_data_loader_stack.py
@@ -37,3 +37,5 @@ class LlamaindexBasicDataLoaderStack(Stack):
             # docker_image_asset_directory=path.dirname(__file__) + path.sep + ".." + path.sep + "docker",
             container_logging_level="DEBUG",
         )
+
+        self.template_options.description= "Description: (uksb-1tupboc43) (tag: llamaindex data loader sample)",

--- a/samples/python-samples/python_samples/bedrock_opensearch_stack.py
+++ b/samples/python-samples/python_samples/bedrock_opensearch_stack.py
@@ -72,7 +72,6 @@ class BedrockOpensearchStack(Stack):
             user_input_enabled= True,
             should_prepare_agent=True
             )
-       
      ## associate action group  with agent
         agent.add_action_group(ag)   
         
@@ -82,7 +81,8 @@ class BedrockOpensearchStack(Stack):
                                         description='alias for my agent',
                                         agent=agent)
        
-
+        self.template_options.description='Description: (uksb-1tupboc43) (tag: python bedrock sample)'
+        
         CfnOutput(self, "KnowledgeBaseId", value=kb.knowledge_base_id)
         CfnOutput(self, 'agentid', value= agent.agent_id)
         CfnOutput(self, 'DataSourceId', value= dataSource.data_source_id)

--- a/samples/python-samples/python_samples/prompt_management.py
+++ b/samples/python-samples/python_samples/prompt_management.py
@@ -81,7 +81,6 @@ class PromptManagementStack(Stack):
                 "maxTokens": 2000,
             }
         )
-
         prompt.add_variant(variant2)
 
         

--- a/samples/python-samples/python_samples/prompt_management.py
+++ b/samples/python-samples/python_samples/prompt_management.py
@@ -81,6 +81,9 @@ class PromptManagementStack(Stack):
                 "maxTokens": 2000,
             }
         )
+        
+        self.template_options.description='Description: (uksb-1tupboc43) (tag: python prompt management sample)'
+
         prompt.add_variant(variant2)
 
         

--- a/samples/rfp-answer-generation/backend/stack/inference_stack.py
+++ b/samples/rfp-answer-generation/backend/stack/inference_stack.py
@@ -109,6 +109,9 @@ class InferenceStack(Stack):
             self.sfn.state_machine,
         )
 
+        self.template_options.description='Description: (uksb-1tupboc43) (tag: rfp answer generation sample)'
+
+
         NagSuppressions.add_resource_suppressions_by_path(
             stack=self,
             path=f"/{Stack.of(self).stack_name}/BucketNotificationsHandler050a0587b7544547bf325f094a3db834/Role/Resource",

--- a/samples/rfp-answer-generation/backend/stack/ingestion_stack.py
+++ b/samples/rfp-answer-generation/backend/stack/ingestion_stack.py
@@ -242,6 +242,9 @@ class IngestionStack(Stack):
             ),
         )
 
+        self.template_options.description='Description: (uksb-1tupboc43) (tag: rfp answer generation sample)'
+
+
         NagSuppressions.add_resource_suppressions(
             construct=self.faq_custom_transformation_function.role,
             suppressions=[

--- a/samples/sagemaker_custom_endpoint/bin/sagemaker_custom_endpoint.ts
+++ b/samples/sagemaker_custom_endpoint/bin/sagemaker_custom_endpoint.ts
@@ -20,7 +20,7 @@ new SagemakerCustomEndpointStack(app, 'SagemakerCustomEndpointStack', {
   env: {
     region: 'us-east-2'
   },
-  description: '(uksb-1tupboc43) Sagemaker Custom Endpoint Stack'
+  description: '(uksb-1tupboc43) (tag: Sagemaker Custom Endpoint Stack)'
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/samples/sagemaker_custom_endpoint/bin/sagemaker_custom_endpoint.ts
+++ b/samples/sagemaker_custom_endpoint/bin/sagemaker_custom_endpoint.ts
@@ -20,7 +20,6 @@ new SagemakerCustomEndpointStack(app, 'SagemakerCustomEndpointStack', {
   env: {
     region: 'us-east-2'
   },
-  description: '(uksb-1tupboc43) (tag: Sagemaker Custom Endpoint Stack)'
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/samples/sagemaker_custom_endpoint/lib/sagemaker_custom_endpoint-stack.ts
+++ b/samples/sagemaker_custom_endpoint/lib/sagemaker_custom_endpoint-stack.ts
@@ -40,6 +40,8 @@ export class SagemakerCustomEndpointStack extends cdk.Stack {
       volumeSizeInGb: 100
     });
 
+    this.templateOptions.description= 'Description: (uksb-1tupboc43) (tag: Sagemaker Custom Endpoint Stack)'
+
     customEndpoint.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/samples/sagemaker_huggingface_inferentia/lib/sagemaker_huggingface_inferentia-stack.ts
+++ b/samples/sagemaker_huggingface_inferentia/lib/sagemaker_huggingface_inferentia-stack.ts
@@ -41,6 +41,8 @@ export class SagemakerHuggingfaceInferentiaStack extends cdk.Stack {
       endpointName: SG_ENDPOINT_NAME
     });
 
+    this.templateOptions.description= 'Description: (uksb-1tupboc43) (tag: Sagemaker hugging face infrentia Stack)'
+
     // Lambda request handler used to interact with the SageMaker endpoint
     const requestHandler = new lambda.Function(this, 'DemoRequestHandlerHuggingFaceInferentia', {
       code: lambda.Code.fromAsset(

--- a/samples/sagemaker_huggingface_model/bin/sagemaker_huggingface_model.ts
+++ b/samples/sagemaker_huggingface_model/bin/sagemaker_huggingface_model.ts
@@ -19,8 +19,7 @@ const app = new cdk.App();
 new SagemakerHuggingfaceModelStack(app, 'SagemakerHuggingfaceModelStack', {
   env: {
     region: 'us-east-1'
-  },
-  description: '(uksb-1tupboc43) (tag: Sagemaker Hugging face model Stack)'
+  }
 
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,

--- a/samples/sagemaker_huggingface_model/bin/sagemaker_huggingface_model.ts
+++ b/samples/sagemaker_huggingface_model/bin/sagemaker_huggingface_model.ts
@@ -20,7 +20,7 @@ new SagemakerHuggingfaceModelStack(app, 'SagemakerHuggingfaceModelStack', {
   env: {
     region: 'us-east-1'
   },
-  description: '(uksb-1tupboc43) Sagemaker Hugging face model Stack'
+  description: '(uksb-1tupboc43) (tag: Sagemaker Hugging face model Stack)'
 
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,

--- a/samples/sagemaker_huggingface_model/lib/sagemaker_huggingface_model-stack.ts
+++ b/samples/sagemaker_huggingface_model/lib/sagemaker_huggingface_model-stack.ts
@@ -38,6 +38,8 @@ export class SagemakerHuggingfaceModelStack extends cdk.Stack {
       endpointName: SG_ENDPOINT_NAME
     });
 
+    this.templateOptions.description = 'Description: (uksb-1tupboc43) (tag: Sagemaker Hugging face model Stack)'
+
     // Lambda request handler used to interact with the SageMaker endpoint
     const requestHandler = new lambda.Function(this, 'DemoRequestHandlerHuggingFace', {
       code: lambda.Code.fromAsset(

--- a/samples/sagemaker_huggingface_model_llava/bin/sagemaker_huggingface_model_llava.ts
+++ b/samples/sagemaker_huggingface_model_llava/bin/sagemaker_huggingface_model_llava.ts
@@ -8,7 +8,7 @@ new SagemakerHuggingfaceModelLlavaStack(app, 'SagemakerHuggingfaceModelLlavaStac
   env: {
     region: 'us-east-1'
   },
-  description: '(uksb-1tupboc43) Sagemaker Custom Hugging Face Endpoint Stack'
+  description: '(uksb-1tupboc43) (tag: Sagemaker Custom Hugging Face Endpoint Stack)'
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/samples/sagemaker_huggingface_model_llava/bin/sagemaker_huggingface_model_llava.ts
+++ b/samples/sagemaker_huggingface_model_llava/bin/sagemaker_huggingface_model_llava.ts
@@ -8,7 +8,6 @@ new SagemakerHuggingfaceModelLlavaStack(app, 'SagemakerHuggingfaceModelLlavaStac
   env: {
     region: 'us-east-1'
   },
-  description: '(uksb-1tupboc43) (tag: Sagemaker Custom Hugging Face Endpoint Stack)'
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/samples/sagemaker_huggingface_model_llava/lib/sagemaker_huggingface_model_llava-stack.ts
+++ b/samples/sagemaker_huggingface_model_llava/lib/sagemaker_huggingface_model_llava-stack.ts
@@ -41,6 +41,8 @@ export class SagemakerHuggingfaceModelLlavaStack extends cdk.Stack {
       modelDataDownloadTimeoutInSeconds: 900,
     });
 
+    this.templateOptions.description = 'Description: (uksb-1tupboc43) (tag: Sagemaker Hugging Face llava Sample)'
+
     CustomHuggingFaceEndpoint.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/samples/sagemaker_huggingface_model_svd/bin/sagemaker_huggingface_model_svd.ts
+++ b/samples/sagemaker_huggingface_model_svd/bin/sagemaker_huggingface_model_svd.ts
@@ -10,5 +10,5 @@ const app = new cdk.App();
 cdk.Tags.of(app).add("app", "generative-ai-cdk-constructs-samples");
 cdk.Aspects.of(app).add(new AwsSolutionsChecks({verbose: true}));
 new SagemakerHuggingfaceModelSvdStack(app, 'SagemakerHuggingfaceModelSvdStack', {
-  description: '(uksb-1tupboc43) Custom Async Endpoint Layer stack',
+  description: '(uksb-1tupboc43) (tag: Custom Async Endpoint Layer stack)',
 });

--- a/samples/sagemaker_huggingface_model_svd/bin/sagemaker_huggingface_model_svd.ts
+++ b/samples/sagemaker_huggingface_model_svd/bin/sagemaker_huggingface_model_svd.ts
@@ -10,5 +10,4 @@ const app = new cdk.App();
 cdk.Tags.of(app).add("app", "generative-ai-cdk-constructs-samples");
 cdk.Aspects.of(app).add(new AwsSolutionsChecks({verbose: true}));
 new SagemakerHuggingfaceModelSvdStack(app, 'SagemakerHuggingfaceModelSvdStack', {
-  description: '(uksb-1tupboc43) (tag: Custom Async Endpoint Layer stack)',
 });

--- a/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
+++ b/samples/sagemaker_huggingface_model_svd/lib/sagemaker_huggingface_model_svd-stack.ts
@@ -56,6 +56,10 @@ export class SagemakerHuggingfaceModelSvdStack extends cdk.Stack {
       }
     });
 
+
+    this.templateOptions.description= 'Description: (uksb-1tupboc43) (tag: Custom Async Endpoint Layer stack)',
+
+
     CustomHuggingFaceEndpoint.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/samples/sagemaker_jumpstart_model/bin/sagemaker_jumpstart_model.ts
+++ b/samples/sagemaker_jumpstart_model/bin/sagemaker_jumpstart_model.ts
@@ -20,7 +20,7 @@ new SagemakerJumpstartModelStack(app, 'SagemakerJumpstartModelStack', {
   env: {
     region: 'us-east-1'
   },
-  description: '(uksb-1tupboc43) Sagemaker Jumpstart Model Stack'
+  description: '(uksb-1tupboc43) (tag: Sagemaker Jumpstart Model Stack)'
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/samples/sagemaker_jumpstart_model/bin/sagemaker_jumpstart_model.ts
+++ b/samples/sagemaker_jumpstart_model/bin/sagemaker_jumpstart_model.ts
@@ -20,7 +20,6 @@ new SagemakerJumpstartModelStack(app, 'SagemakerJumpstartModelStack', {
   env: {
     region: 'us-east-1'
   },
-  description: '(uksb-1tupboc43) (tag: Sagemaker Jumpstart Model Stack)'
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/samples/sagemaker_jumpstart_model/lib/sagemaker_jumpstart_model-stack.ts
+++ b/samples/sagemaker_jumpstart_model/lib/sagemaker_jumpstart_model-stack.ts
@@ -31,6 +31,9 @@ export class SagemakerJumpstartModelStack extends cdk.Stack {
       endpointName: SG_ENDPOINT_NAME
     });
 
+    this.templateOptions.description= 'Description: (uksb-1tupboc43) (tag: Sagemaker Jumpstart Model Stack)'
+
+
     // Lambda request handler used to interact with the SageMaker endpoint
     const requestHandler = new lambda.Function(this, 'DemoRequestHandlerJumpstart', {
       code: lambda.Code.fromAsset(


### PR DESCRIPTION


*Description of changes:*
The SAES Metric dashboard now supports monorepo. Adding tag for each sample so that it can be tracked at sample level on dashboard.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
