### PR TITLE
docs: Correct architecture description for the Inference stack

### DIFF
--- a/samples/rfp-answer-generation/README.md
+++ b/samples/rfp-answer-generation/README.md
@@ -34,7 +34,7 @@ Components deployed by this stack include:
 
 ### Inference stack
 
-The inference stack configures a workflow for processing new, incoming RFPs. It breaks the RFP down into questions, then prompts the LLM to use context from the Knowledge Base (deployed in the inference stack) to answer each question.
+The inference stack configures a workflow for processing new, incoming RFPs. It breaks the RFP down into questions, then prompts the LLM to use context from the Knowledge Base (which is deployed in the ingestion stack) to answer each question.
 
 The generated answer and the original question are saved into an Amazon DynamoDB table.
 


### PR DESCRIPTION
This correction aligns the text with the diagram, clarifying that the "Inference stack" consumes the Knowledge Base, but it is deployed by the "Ingestion stack". This improves accuracy and clarity for anyone reading or implementing the project.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
